### PR TITLE
Py3 compat (run 2to3 on codebase)

### DIFF
--- a/Skeletron/input.py
+++ b/Skeletron/input.py
@@ -86,7 +86,7 @@ def parse_route_relation_waynodes(input, merge_highways):
     while changing:
         changing = False
     
-        for rel in rels.values():
+        for rel in list(rels.values()):
             parts = rel['parts']
 
             for (index, part) in enumerate(parts):
@@ -127,7 +127,7 @@ def parse_route_relation_waynodes(input, merge_highways):
     highways = dict(motorway=9, trunk=8, primary=7, secondary=6, tertiary=5)
     net_refs = dict()
     
-    for rel in rels.values():
+    for rel in list(rels.values()):
         for part in rel['parts']:
             # we know from above that they're all "way:".
             way_id = part[4:]
@@ -164,7 +164,7 @@ def parse_route_relation_waynodes(input, merge_highways):
         # Run through the list again, assigning largest highway
         # values from net_refs dictionary to each way key.
         #
-        for (key, rel_way) in rel_ways.items():
+        for (key, rel_way) in list(rel_ways.items()):
             network, ref, modifier = rel_way['key']
             highway = net_refs[(network, ref, modifier)]
             rel_ways[key]['key'] = network, ref, modifier, highway

--- a/Skeletron/output.py
+++ b/Skeletron/output.py
@@ -15,7 +15,7 @@ def generalize_geojson_feature(feature, width, zoom):
     
         If generalization fails, return False.
     '''
-    prop = dict([(k.lower(), v) for (k, v) in feature['properties'].items()])
+    prop = dict([(k.lower(), v) for (k, v) in list(feature['properties'].items())])
     name = prop.get('name', prop.get('id', prop.get('gid', prop.get('fid', None))))
     geom = asShape(feature['geometry'])
 
@@ -64,7 +64,7 @@ def multilines_geojson(multilines, key_properties, buffer, density, min_length, 
         try:
             centerline = multigeom_centerline(multiline, buffer, density, min_length, min_area)
         
-        except _GraphRoutesOvertime, e:
+        except _GraphRoutesOvertime as e:
             #
             # Catch overtimes here because they seem to affect larger networks
             # and therefore most or all of a complex multiline. We'll keep the
@@ -95,7 +95,7 @@ def generalized_multiline(multiline, buffer, density, min_length, min_area):
     try:
         centerline = multigeom_centerline(multiline, buffer, density, min_length, min_area)
     
-    except Exception, e:
+    except Exception as e:
         raise
         logging.error(e)
         return None

--- a/Skeletron/util.py
+++ b/Skeletron/util.py
@@ -3,8 +3,8 @@ from math import hypot, ceil, sqrt, pi
 from base64 import b64encode, b64decode
 from json import loads as json_decode
 from json import dumps as json_encode
-from cPickle import loads as unpickle
-from cPickle import dumps as pickle
+from pickle import loads as unpickle
+from pickle import dumps as pickle
 from os.path import splitext
 from gzip import GzipFile
 from bz2 import BZ2File
@@ -46,7 +46,7 @@ def point_distance(a, b):
     try:
         return a.distance(b)
 
-    except ValueError, e:
+    except ValueError as e:
         if str(e) != 'Prepared geometries cannot be operated on':
             raise
         
@@ -64,7 +64,7 @@ def simplify_line_vw(points, small_area=100):
     
         popped, preserved = set(), set()
         
-        triples = zip(points[:-2], points[1:-1], points[2:])
+        triples = list(zip(points[:-2], points[1:-1], points[2:]))
         triangles = [Polygon((p1, p2, p3)) for (p1, p2, p3) in triples]
         areas = [(triangle.area, index) for (index, triangle) in enumerate(triangles)]
         

--- a/osm-slurp.py
+++ b/osm-slurp.py
@@ -11,9 +11,9 @@ from Skeletron.draw import Canvas
 p = ParserOSM()
 g = p.parse(stdin)
 
-print sorted(g.keys())
+print(sorted(g.keys()))
 
-network = g[(u'Lakeside Drive', u'secondary')]
+network = g[('Lakeside Drive', 'secondary')]
 
 if not network.edges():
     exit(1)

--- a/osm-to-json.py
+++ b/osm-to-json.py
@@ -13,7 +13,7 @@ g = p.parse(stdin)
 output = dict(type='FeatureCollection', features=[])
 
 for key in g:
-    print key
+    print(key)
     network = g[key]
     
     if not network.edges():

--- a/skeletron-generalize.py
+++ b/skeletron-generalize.py
@@ -57,7 +57,7 @@ if __name__ == '__main__':
             if not feature:
                 continue
 
-        except Exception, err:
+        except Exception as err:
             logging.error('Error on feature #%d: %s' % (index, err))
 
         else:
@@ -76,7 +76,7 @@ if __name__ == '__main__':
     # Output
     #
     
-    geojson = dict(type='FeatureCollection', features=filter(None, features))
+    geojson = dict(type='FeatureCollection', features=[_f for _f in features if _f])
     output = open(output_file, 'w')
 
     encoder = JSONEncoder(separators=(',', ':'))

--- a/skeletron-hadoop-mapper.py
+++ b/skeletron-hadoop-mapper.py
@@ -36,14 +36,14 @@ if __name__ == '__main__':
                 logging.debug('Empty skeleton')
                 continue
             
-        except Exception, e:
+        except Exception as e:
             logging.error(str(e))
             continue
         
         if id is None:
             for (index, bone) in enumerate(bones):
                 logging.info('line %d of %d from %s' % (1 + index, len(bones), dumps(prop)))
-                print >> stdout, hadoop_feature_line(id, prop, bone)
+                print(hadoop_feature_line(id, prop, bone), file=stdout)
         else:
             logging.info('%d-part multiline from %s' % (len(bones), dumps(prop)))
-            print >> stdout, hadoop_feature_line(id, prop, skeleton)
+            print(hadoop_feature_line(id, prop, skeleton), file=stdout)

--- a/skeletron-hadoop-reducer.py
+++ b/skeletron-hadoop-reducer.py
@@ -24,7 +24,7 @@ if __name__ == '__main__':
         try:
             features.extend(hadoop_line_features(line))
         
-        except Exception, e:
+        except Exception as e:
             logging.error(str(e))
             continue
 

--- a/skeletron-osm-route-rels.py
+++ b/skeletron-osm-route-rels.py
@@ -66,11 +66,13 @@ if __name__ == '__main__':
     kwargs = dict(buffer=buffer, density=buffer/2, min_length=8*buffer, min_area=(buffer**2)/4)
     
     if options.merge_highways == 'yes':
-        def key_properties((network, ref, modifier)):
+        def key_properties(xxx_todo_changeme):
+            (network, ref, modifier) = xxx_todo_changeme
             return dict(network=network, ref=ref, modifier=modifier,
                         zoomlevel=options.zoom, pixelwidth=options.width)
     else:
-        def key_properties((network, ref, modifier, highway)):
+        def key_properties(xxx_todo_changeme1):
+            (network, ref, modifier, highway) = xxx_todo_changeme1
             return dict(network=network, ref=ref, modifier=modifier, highway=highway,
                         zoomlevel=options.zoom, pixelwidth=options.width)
 

--- a/skeletron-osm-streets.py
+++ b/skeletron-osm-streets.py
@@ -63,18 +63,20 @@ if __name__ == '__main__':
     kwargs = dict(buffer=buffer, density=buffer/2, min_length=2*buffer, min_area=(buffer**2)/4)
     
     if options.use_highway:
-        def key_properties((name, highway)):
+        def key_properties(xxx_todo_changeme):
+            (name, highway) = xxx_todo_changeme
             return dict(name=name, highway=highway,
                         zoomlevel=options.zoom, pixelwidth=options.width,
                         shortname=short_street_name(name))
     else:
-        def key_properties((name, )):
+        def key_properties(xxx_todo_changeme1):
+            (name, ) = xxx_todo_changeme1
             return dict(name=name,
                         zoomlevel=options.zoom, pixelwidth=options.width,
                         shortname=short_street_name(name))
 
-    print >> stderr, 'Buffer: %(buffer).1f, density: %(density).1f, minimum length: %(min_length).1f, minimum area: %(min_area).1f.' % kwargs
-    print >> stderr, '-' * 20
+    print('Buffer: %(buffer).1f, density: %(density).1f, minimum length: %(min_length).1f, minimum area: %(min_area).1f.' % kwargs, file=stderr)
+    print('-' * 20, file=stderr)
 
     geojson = multilines_geojson(multilines, key_properties, **kwargs)
     output = open_file(output_file, 'w')

--- a/skeletron-pgdump-route-rels.py
+++ b/skeletron-pgdump-route-rels.py
@@ -17,11 +17,11 @@ def write_groups(queue):
         try:
             group = queue.get(timeout=300)
         except:
-            print 'bah'
+            print('bah')
             break
         
         tree = make_group_tree(group)
-        file = BZ2File(names.next(), mode='w')
+        file = BZ2File(next(names), mode='w')
 
         tree.write(file)
         file.close()
@@ -212,7 +212,7 @@ def gen_relation_groups(relations):
         rel_coords = sum([len(line.coords) for line in way_lines if line])
         #multiline = cascaded_union(way_lines)
         
-        print >> stderr, ', '.join(key), '--', rel_coords, 'nodes'
+        print(', '.join(key), '--', rel_coords, 'nodes', file=stderr)
         
         group.append((id, tags, way_tags, way_lines))
         coords += rel_coords
@@ -228,23 +228,23 @@ def make_group_tree(group):
 
     for (id, tags, way_tags, way_lines) in group:
     
-        rel = Element('relation', dict(id=ids.next(), version='1', timestamp='0000-00-00T00:00:00Z'))
+        rel = Element('relation', dict(id=next(ids), version='1', timestamp='0000-00-00T00:00:00Z'))
         
-        for (k, v) in tags.items():
+        for (k, v) in list(tags.items()):
             rel.append(Element('tag', dict(k=k, v=v)))
         
         for (tags, line) in zip(way_tags, way_lines):
             if not line:
                 continue
         
-            way = Element('way', dict(id=ids.next(), version='1', timestamp='0000-00-00T00:00:00Z'))
+            way = Element('way', dict(id=next(ids), version='1', timestamp='0000-00-00T00:00:00Z'))
             
-            for (k, v) in tags.items():
+            for (k, v) in list(tags.items()):
                 way.append(Element('tag', dict(k=k, v=v)))
             
             for coord in line.coords:
                 lon, lat = '%.7f' % coord[0], '%.7f' % coord[1]
-                node = Element('node', dict(id=ids.next(), lat=lat, lon=lon, version='1', timestamp='0000-00-00T00:00:00Z'))
+                node = Element('node', dict(id=next(ids), lat=lat, lon=lon, version='1', timestamp='0000-00-00T00:00:00Z'))
                 nd = Element('nd', dict(ref=node.attrib['id']))
 
                 osm.append(node)
@@ -272,7 +272,7 @@ if __name__ == '__main__':
     for group in gen_relation_groups(relations):
         queue.put(group)
 
-        print >> stderr, '-->', len(group), 'relations'
-        print >> stderr, '-' * 80
+        print('-->', len(group), 'relations', file=stderr)
+        print('-' * 80, file=stderr)
     
     group_writer.join()

--- a/voronoi-look.py
+++ b/voronoi-look.py
@@ -58,7 +58,7 @@ for (x, y) in points:
     ctx.set_source_rgb(.6, .6, .6)
     ctx.fill()
 
-print 'qhull...'
+print('qhull...')
 
 rbox = '\n'.join( ['2', str(len(points))] + ['%.2f %.2f' % (x, y) for (x, y) in points] + [''] )
 
@@ -68,19 +68,19 @@ qhull.stdin.close()
 sleep(1) # qhull.wait()
 qhull = qhull.stdout.read().splitlines()
 
-vert_count, poly_count = map(int, qhull[1].split()[:2])
+vert_count, poly_count = list(map(int, qhull[1].split()[:2]))
 
-print 'graph...'
+print('graph...')
 
 skeleton = Graph()
 
 for (index, line) in enumerate(qhull[2:2+vert_count]):
-    point = Point(*map(float, line.split()[:2]))
+    point = Point(*list(map(float, line.split()[:2])))
     if point.within(polygon):
         skeleton.add_node(index, dict(point=point))
 
 for line in qhull[2 + vert_count:2 + vert_count + poly_count]:
-    indexes = map(int, line.split()[1:])
+    indexes = list(map(int, line.split()[1:]))
     for (v, w) in zip(indexes, indexes[1:] + indexes[:1]):
         if v not in skeleton.node or w not in skeleton.node:
             continue
@@ -89,7 +89,7 @@ for line in qhull[2 + vert_count:2 + vert_count + poly_count]:
         if line.within(polygon):
             skeleton.add_edge(v, w, dict(line=line, length=line.length))
 
-print 'trim...'
+print('trim...')
 
 removing = True
 
@@ -105,7 +105,7 @@ while removing:
                 skeleton.remove_node(index)
                 removing = True
 
-print 'draw...'
+print('draw...')
 
 for index in skeleton.nodes():
     point = skeleton.node[index]['point']


### PR DESCRIPTION
I have switched to Python 3, as all of my main dependencies now support it. Your Skeletron package only failed due to some Syntax errors, which a mindless run of `2to3` could apparently fix. The Skeletron function `polygon_skeletron_graphs` works [for me](https://github.com/ojdo/python-tools/blob/master/skeletrontools.py) with these changes. However, I did _not_ test drive the modified scripts or other functions.

And: thanks for this handy toolbox!
